### PR TITLE
Show segmentation error stacktrace.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG=C.UTF-8 \
 
 # CMake accepts the following build types: Debug, Release, RelWithDebInfo.
 # So, for a debug build, you would run TYPE=Debug instead of TYPE=Release.
-ENV TYPE=Release
+ENV TYPE=Debug
 ENV PATH="/adm-scripts:/adm-scripts/kms:$PATH"
 
 RUN git clone https://github.com/Kurento/adm-scripts.git \
@@ -28,12 +28,14 @@ RUN git clone https://github.com/Kurento/kms-omni-build.git /.kms \
  && git checkout 722df59b98dcdeda12151ee2d3a32c847e3fee62 \
  ## kms-elements fork
  && git config -f .gitmodules submodule.kms-elements.url https://github.com/instrumentisto/kms-elements.git \
- && git config -f .gitmodules submodule.kms-elements.branch master \
+ && git config -f .gitmodules submodule.kms-elements.branch 162-kurento-segfault \
+ && git config -f .gitmodules submodule.kms-cmake-utils.url https://github.com/flexconstructor/kms-cmake-utils.git \
+ && git config -f .gitmodules submodule.kms-cmake-utils.branch 162-kurento-segfault \
  ## init
  && git submodule update --init --recursive \
  ## kms-cmake-utils
  && cd kms-cmake-utils \
- && git checkout b931efc0f5f095698956ba29f85b4aa1d784e3e0 \
+ && git checkout f4a4e151738817433ccf1e849d0817e13ff64190 \
  && cd .. \
  ## kms-jsonrpc
  && cd kms-jsonrpc \
@@ -49,7 +51,7 @@ RUN git clone https://github.com/Kurento/kms-omni-build.git /.kms \
  && cd .. \
  ## kms-elements
  && cd kms-elements \
- && git checkout 6b4ad504c624c9f8c5714509ffe377ed5622a639 \
+ && git checkout 6191353154ec7ac39165228f41b56cfd236828f4 \
  && cd .. \
  ## kms-filters
  && cd kms-filters \
@@ -138,6 +140,8 @@ ENV GST_DEBUG="3,Kurento*:3,kms*:3,sdp*:3,webrtc*:4,*rtpendpoint:4,rtp*handler:4
 COPY --from=build /dist /
 
 COPY rootfs /
+
+RUN cp /kurento-media-server/server/kurento-media-server /usr/bin/kurento-media-server
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83 \
  && echo "deb http://ubuntu.openvidu.io/dev xenial kms6" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ RUN git clone https://github.com/Kurento/kms-omni-build.git /.kms \
  && git checkout 722df59b98dcdeda12151ee2d3a32c847e3fee62 \
  ## kms-elements fork
  && git config -f .gitmodules submodule.kms-elements.url https://github.com/instrumentisto/kms-elements.git \
- && git config -f .gitmodules submodule.kms-elements.branch 162-kurento-segfault \
+ && git config -f .gitmodules submodule.kms-elements.branch master \
  && git config -f .gitmodules submodule.kurento-media-server.url https://github.com/flexconstructor/kurento-media-server.git \
- && git config -f .gitmodules submodule.kurento-media-server.branch 162-kurento-segfault \
+ && git config -f .gitmodules submodule.kurento-media-server.branch master \
  ## init
  && git submodule update --init --recursive \
  ## kms-cmake-utils
@@ -51,7 +51,7 @@ RUN git clone https://github.com/Kurento/kms-omni-build.git /.kms \
  && cd .. \
  ## kms-elements
  && cd kms-elements \
- && git checkout 6191353154ec7ac39165228f41b56cfd236828f4 \
+ && git checkout 6b4ad504c624c9f8c5714509ffe377ed5622a639 \
  && cd .. \
  ## kms-filters
  && cd kms-filters \
@@ -59,7 +59,7 @@ RUN git clone https://github.com/Kurento/kms-omni-build.git /.kms \
  && cd .. \
  ## kurento-media-server
  && cd kurento-media-server \
- && git checkout 4c76c7d9354468bd7d2b1b5545001c8e2ac0eef1 \
+ && git checkout f48684873b269cbe0e32ecf1a5821c8abc090896 \
  && cd .. \
  && mkdir -p /.kms/build/ \
  && cd /.kms/build/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN git clone https://github.com/Kurento/adm-scripts.git \
  && /adm-scripts/development/kurento-repo-xenial-nightly-2018 \
  && /adm-scripts/development/kurento-install-development
 
-
 FROM builder AS build
 
 # Download Kurento media server project sources
@@ -30,7 +29,7 @@ RUN git clone https://github.com/Kurento/kms-omni-build.git /.kms \
  && git config -f .gitmodules submodule.kms-elements.url https://github.com/instrumentisto/kms-elements.git \
  && git config -f .gitmodules submodule.kms-elements.branch 162-kurento-segfault \
  && git config -f .gitmodules submodule.kms-cmake-utils.url https://github.com/flexconstructor/kms-cmake-utils.git \
- && git config -f .gitmodules submodule.kms-cmake-utils.branch 162-kurento-segfault \
+ && git config -f .gitmodules submodule.kms-cmake-utils.url.branch 162-kurento-segfault \
  ## init
  && git submodule update --init --recursive \
  ## kms-cmake-utils
@@ -68,6 +67,7 @@ RUN git clone https://github.com/Kurento/kms-omni-build.git /.kms \
           -DSANITIZE_ADDRESS=ON \
           -DSANITIZE_THREAD=ON \
           -DSANITIZE_LINK_STATIC=ON \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
         .. \
  && make  \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,13 @@ ENV LANG=C.UTF-8 \
 
 # CMake accepts the following build types: Debug, Release, RelWithDebInfo.
 # So, for a debug build, you would run TYPE=Debug instead of TYPE=Release.
-ENV TYPE=Debug
+ENV TYPE=Release
 ENV PATH="/adm-scripts:/adm-scripts/kms:$PATH"
 
 RUN git clone https://github.com/Kurento/adm-scripts.git \
  && /adm-scripts/development/kurento-repo-xenial-nightly-2018 \
  && /adm-scripts/development/kurento-install-development
+
 
 FROM builder AS build
 
@@ -28,13 +29,13 @@ RUN git clone https://github.com/Kurento/kms-omni-build.git /.kms \
  ## kms-elements fork
  && git config -f .gitmodules submodule.kms-elements.url https://github.com/instrumentisto/kms-elements.git \
  && git config -f .gitmodules submodule.kms-elements.branch 162-kurento-segfault \
- && git config -f .gitmodules submodule.kms-cmake-utils.url https://github.com/flexconstructor/kms-cmake-utils.git \
- && git config -f .gitmodules submodule.kms-cmake-utils.url.branch 162-kurento-segfault \
+ && git config -f .gitmodules submodule.kurento-media-server.url https://github.com/flexconstructor/kurento-media-server.git \
+ && git config -f .gitmodules submodule.kurento-media-server.branch 162-kurento-segfault \
  ## init
  && git submodule update --init --recursive \
  ## kms-cmake-utils
  && cd kms-cmake-utils \
- && git checkout f4a4e151738817433ccf1e849d0817e13ff64190 \
+ && git checkout b931efc0f5f095698956ba29f85b4aa1d784e3e0 \
  && cd .. \
  ## kms-jsonrpc
  && cd kms-jsonrpc \
@@ -58,7 +59,7 @@ RUN git clone https://github.com/Kurento/kms-omni-build.git /.kms \
  && cd .. \
  ## kurento-media-server
  && cd kurento-media-server \
- && git checkout d7c98feb60938c8b4da952363fd98da2f1f1b869 \
+ && git checkout 4c76c7d9354468bd7d2b1b5545001c8e2ac0eef1 \
  && cd .. \
  && mkdir -p /.kms/build/ \
  && cd /.kms/build/ \
@@ -141,8 +142,6 @@ COPY --from=build /dist /
 
 COPY rootfs /
 
-RUN cp /kurento-media-server/server/kurento-media-server /usr/bin/kurento-media-server
-
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83 \
  && echo "deb http://ubuntu.openvidu.io/dev xenial kms6" \
     | tee /etc/apt/sources.list.d/kurento.list
@@ -187,6 +186,7 @@ RUN apt-get update \
           /kurento-media-server/plugins/libwebrtcdataproto.so \
  && ln -s /usr/local/lib/libkmscoreimpl.so.6 \
           /kurento-media-server/plugins/libkmscoreimpl.so \
+ && cp /kurento-media-server/server/kurento-media-server /usr/bin/kurento-media-server \
  && ldconfig \
  # Ensure correct rights on executables
  && chmod +x /entrypoint.sh \

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@
 
 
 IMAGE_NAME := instrumentisto/kurento
-VERSION ?= 6.9.0-r2
-TAGS ?= 6.9.0-r2,6.9.0,6.9,6,latest
+VERSION ?= 6.9.0-sf
+TAGS ?= 6.9.0-sf,6.9.0,6.9,6,latest
 
 
 comma := ,

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@
 
 
 IMAGE_NAME := instrumentisto/kurento
-VERSION ?= 6.9.0-sf
-TAGS ?= 6.9.0-sf,6.9.0,6.9,6,latest
+VERSION ?= 6.9.0-r3
+TAGS ?= 6.9.0-r3,6.9.0,6.9,6,latest
 
 
 comma := ,

--- a/goss.yaml
+++ b/goss.yaml
@@ -9,42 +9,42 @@ package:
   libgstreamer1.5-0:amd64:
     installed: true
     versions:
-      - 1.8.1.1.xenial~20181018130734.170.0d6031b
+      - 1.8.1-1kurento1.16.04~20190214125843.gbp059291
   # gstreamer1.5-plugins-base installed
   gstreamer1.5-plugins-base:
     installed: true
     versions:
-      - 1.8.1.1.xenial~20181018132104.55.7b19cfd
+      - 1.8.1-1kurento1.16.04~20190214125843.gbp330b77
   # libnice installed
   gstreamer1.5-nice:
     installed: true
     versions:
-      - 0.1.15-1kurento2~20181207131058.gbp03e0b4
+      - 0.1.15-1kurento2.16.04~20190214125843.gbpaa63a5
   # gstreamer1.5-plugins-bad installed
   gstreamer1.5-plugins-bad:amd64:
     installed: true
     versions:
-      - 1.8.1.1.xenial~20181018134602.100.3db37b1
+      - 1.8.1-1kurento1.16.04~20190214125843.gbp1d8070
   # gstreamer1.5-plugins-ugly installed
   gstreamer1.5-plugins-ugly:
     installed: true
     versions:
-      - 1.8.1.1.xenial~20181018140138.89.2685b0f
+      - 1.8.1-1kurento1.16.04~20190214125843.gbpbed8b0
   # gstreamer1.5-libav installed
   gstreamer1.5-libav:
     installed: true
     versions:
-      - 1.8.2.1.xenial~20181018140706.96.493eee4
+      - 1.8.1-1kurento1.16.04~20190214125843.gbpb33143
   # gstreamer1.5-tools installed
   gstreamer1.5-tools:
     installed: true
     versions:
-      - 1.8.1.1.xenial~20181018130734.170.0d6031b
+      - 1.8.1-1kurento1.16.04~20190214125843.gbp059291
   # checks openh26 installed
   openh264:
     installed: true
     versions:
-      - 1.4.0.xenial~20181018130100.2.5faa3d1
+      - 1.4.0-1kurento1.16.04~20190214125843.gbpb8cb17
 
 # Check Kurento port listening
 port:

--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -25,7 +25,8 @@ fi
 # Remove IPv6 local loop until IPv6 is supported
 cat /etc/hosts | sed '/::1/d' | tee /etc/hosts > /dev/null
 
-exec server/kurento-media-server \
+exec /usr/bin/kurento-media-server \
+  -d /var/log/kurento-media-server \
   --modules-path=. \
   --modules-config-path=./server/config \
   --conf-file=./server/config/kurento.conf.json \


### PR DESCRIPTION
## Synopsis

If a segmentation error occurs, there is no stacktrace in the Kurento logs.

## Solution

1. Run Kurento from the `/usr/bin` directory as [recommended by the developers](https://doc-kurento.readthedocs.io/en/latest/user/troubleshooting.html#media-server-crashed).
2. In case of an accident, terminate Kurento with code 0.

